### PR TITLE
Fully automate dev setup with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,9 +10,8 @@ ports:
 tasks:
   - init: bundle install && yarn install --pure-lockfile && yarn install
       --pure-lockfile && for config in amazon_s3 delayed_jobs domain file_store
-      outgoing_mail security external_migration; \ do cp -v
-      config/$config.yml.example config/$config.yml; done && cp
-      config/dynamic_settings.yml.example config/dynamic_settings.yml && bundle
+      outgoing_mail security external_migration; \
+      do cp -v config/$config.yml.example config/$config.yml; done && cp config/dynamic_settings.yml.example config/dynamic_settings.yml && bundle
       exec rails canvas:compile_assets
 
 github:


### PR DESCRIPTION
This commit implements a fully-automated development setup using Gitpod.io, an
online IDE for GitHub and GitLab that enables Dev-Environments-As-Code.
This makes it easy for anyone to get a ready-to-code workspace for any branch,
issue or pull request almost instantly with a single click.